### PR TITLE
additional liveness chain

### DIFF
--- a/Classes/Command/AppCommandController.php
+++ b/Classes/Command/AppCommandController.php
@@ -18,7 +18,7 @@ use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Result;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
-use Neos\Flow\Log\SystemLoggerInterface;
+use Neos\Flow\Log\ThrowableStorageInterface;
 use Yeebase\Readiness\Service\LivenessTestRunner;
 use Yeebase\Readiness\Service\ReadyTaskRunner;
 use Yeebase\Readiness\Service\TestRunner;
@@ -33,9 +33,9 @@ class AppCommandController extends CommandController
     /**
      * @Flow\Inject
      *
-     * @var SystemLoggerInterface
+     * @var ThrowableStorageInterface
      */
-    protected $systemLogger;
+    protected $throwableStorage;
 
     protected function runReadyTasks(): Result
     {
@@ -57,7 +57,7 @@ class AppCommandController extends CommandController
             return $taskRunner->run();
         } catch (\Throwable $exception) {
             $this->output->output('<error>%s</error>', [$exception->getMessage()]);
-            $this->systemLogger->logException($exception);
+            $this->throwableStorage->logThrowable($exception);
             $result = new Result();
             $result->addError(new Error('Chain failed'));
             return $result;

--- a/Classes/LivenessTest/AbstractLivenessTest.php
+++ b/Classes/LivenessTest/AbstractLivenessTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yeebase\Readiness\LivenessTest;
+
+/**
+ * This file is part of the Yeebase.XY package.
+ *
+ * (c) 2019 yeebase media GmbH
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Yeebase\Readiness\Test\AbstractTest;
+
+abstract class AbstractLivenessTest extends AbstractTest
+{
+}

--- a/Classes/LivenessTest/StatusCodeTest.php
+++ b/Classes/LivenessTest/StatusCodeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yeebase\Readiness\LivenessTest;
+
+/**
+ * This file is part of the Yeebase.XY package.
+ *
+ * (c) 2019 yeebase media GmbH
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\Client\Browser;
+use Neos\Flow\Http\Client\CurlEngine;
+
+class StatusCodeTest extends AbstractLivenessTest
+{
+    /**
+     * @Flow\InjectConfiguration(path="http.baseUri", package="Neos.Flow")
+     *
+     * @var ?string
+     */
+    protected $baseUri;
+
+    public function test(): bool
+    {
+        $browser = new Browser();
+
+        $browser->setRequestEngine(new CurlEngine());
+        $browser->setFollowRedirects($this->options['followRedirects'] ?? true);
+
+        $uri = $this->options['uri'] ?? $this->baseUri ?? 'http://localhost';
+        if ($uri[0] === '/') {
+            $uri = 'http://localhost' . $uri;
+        }
+
+        $response = $browser->request(
+            $uri,
+            $this->options['method'] ?? 'GET',
+            $this->options['arguments'] ?? []
+        );
+
+        return $response->getStatusCode() === ($this->options['statusCode'] ?? 200);
+    }
+}

--- a/Classes/Service/LivenessTestRunner.php
+++ b/Classes/Service/LivenessTestRunner.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yeebase\Readiness\Service;
+
+/**
+ * This file is part of the Yeebase.XY package.
+ *
+ * (c) 2018 yeebase media GmbH
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class LivenessTestRunner extends TestRunner
+{
+    /**
+     * @Flow\InjectConfiguration("livenessChain")
+     *
+     * @var mixed[]
+     */
+    protected $chain;
+
+    /**
+     * @var string
+     */
+    protected $defaultTaskClassName = 'Yeebase\Readiness\LivenessTest\%sTest';
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -54,3 +54,5 @@ Yeebase:
         options:
           expression: '${Lock.set("failed", Chain.getCombinedErrorMessages())}'
         position: 'end 1002'
+
+    livenessChain: []


### PR DESCRIPTION
This PR introduces a new chain for k8s liveness checks: `./flow app:isalive`.

This chain is empty by default but can be configured to check a specific url for a response code:

```
livenessChain:
  yourTestName:
    name: 'Example test'
    test: 'statusCode'
    options:
      statusCode: 200           // default
      uri: 'http://localhost'   // defaults to Neos.Flow.http.baseUri
      method: 'POST'            // defaults to GET
      arguments:                // defaults to []
        param1: value1
```